### PR TITLE
requests missing in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
+    "requests",
     "setuptools>=54",
     "wheel"
 ]


### PR DESCRIPTION
Installed the package, dep was missing and had to install it seperatley.